### PR TITLE
[BUGFIX] Restore initial state of comparator factory

### DIFF
--- a/src/DeepClosureAssert.php
+++ b/src/DeepClosureAssert.php
@@ -36,14 +36,18 @@ final class DeepClosureAssert
 {
     public static function assertEquals(mixed $expected, mixed $actual): void
     {
+        $deepClosureComparator = new DeepClosureComparator();
         $comparatorFactory = Comparator\Factory::getInstance();
-        $comparatorFactory->register(new DeepClosureComparator());
+        $comparatorFactory->register($deepClosureComparator);
 
         try {
             $comparator = $comparatorFactory->getComparatorFor($expected, $actual);
             $comparator->assertEquals($expected, $actual);
         } catch (Comparator\ComparisonFailure $failure) {
             Framework\Assert::fail($failure->getMessage());
+        } finally {
+            // Restore initial state of comparator factory
+            $comparatorFactory->unregister($deepClosureComparator);
         }
 
         // Required to avoid "no assertions" warnings in PHPUnit

--- a/tests/src/DeepClosureAssertTest.php
+++ b/tests/src/DeepClosureAssertTest.php
@@ -27,7 +27,10 @@ use Closure;
 use EliasHaeussler\DeepClosureComparator as Src;
 use Generator;
 use PHPUnit\Framework;
+use SebastianBergmann\Comparator\Factory;
 use stdClass;
+
+use function serialize;
 
 /**
  * DeepClosureAssertTest.
@@ -49,10 +52,23 @@ final class DeepClosureAssertTest extends Framework\TestCase
 
     #[Framework\Attributes\Test]
     #[Framework\Attributes\DataProvider('assertEqualsWithDeepClosureComparisonDoesNotFailIfClosuresAreEqualDataProvider')]
-    #[Framework\Attributes\DoesNotPerformAssertions]
     public function assertEqualsWithDeepClosureComparisonDoesNotFailIfClosuresAreEqual(mixed $expected, mixed $actual): void
     {
         Src\DeepClosureAssert::assertEquals($expected, $actual);
+    }
+
+    #[Framework\Attributes\Test]
+    public function assertEqualsRestoresInitialStateOfComparatorFactory(): void
+    {
+        $factory = Factory::getInstance();
+        $factoryState = serialize($factory);
+
+        $object = new stdClass();
+        $object->foo = static fn () => 'foo';
+
+        Src\DeepClosureAssert::assertEquals($object, $object);
+
+        self::assertSame($factoryState, serialize($factory));
     }
 
     /**


### PR DESCRIPTION
The Comparator Factory is a Singleton and therefore shared across various assertions. Hence, adding a custom comparator modifies subsequent comparators as well, which must be avoided. This PR adds an additional `unregister()` method call on the factory instance to restore the original state of the factory singleton.